### PR TITLE
Update transaction format

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ A comprehensive table has been prepared to display all the characteristics and a
 
 ## SDK Reference
 The library is comprised of primary function files that are responsible for transaction creation. Each of these files contains three primary functions: sign, unsigned, and feeEstimate.
-- signed - The sign function generates and returns a hexadecimal string that represents the signed transaction.
+- signed - The sign function generates and returns the signed transaction.
 - unSigned -  the unsigned function returns an object that contains two fields. The "tx" field contains the transaction itself, while the "unsignedData" field includes an array of data for each unsigned input in the transaction. This data contains all of the necessary arguments required to sign the transaction, including the public key string that can be used to retrieve the corresponding private key. More on this in Advanced Features section.
 - feeEstimate - the feeEstimate function calculates the transaction cost in satoshis, taking into account the fee rates defined in the utility.js variables SATS and PERBYTE. The result of this calculation is then returned as a numerical value.
 
@@ -303,7 +303,7 @@ The token satoshis refer to the total amount of satoshis utilized in the token s
 
 
 ```
-const contractHex =  await stasContract.signed(
+const contractTx =  await stasContract.signed(
     issuerPrivateKey,
     contractUtxo,
     paymentUtxo,
@@ -313,16 +313,15 @@ const contractHex =  await stasContract.signed(
 )
 ```
 
-After executing the function, you will receive a transaction hexadecimal representation that is now ready to be broadcasted to the miner.
+After executing the function, you will receive a transaction object representation. To convert to hexadecimal simply add "toString()", and is now ready to be broadcasted to the miner.
 
-You need to use the contract output #0 UTXO in the issuance function. The utility.js file includes a helper function that retrieves a UTXO object from a transaction hex. This function takes the transaction hex and output index value as arguments.
-
+You need to use the contract output #0 UTXO in the issuance function. The utility.js file includes a helper function that retrieves a UTXO object from a transaction hex. This function takes the transaction and output index value as arguments.
 
 ```
 const stas = require('stas-sdk')
 const {utility} = stas
 
-const contractUtxo = utility.getUtxoFromTx(contractHex, 0)
+const contractUtxo = utility.getUtxoFromTx(contractTx, 0)
 ```
 
 ### Issuance
@@ -436,7 +435,7 @@ protocol : represents the token template used to issue the token and must be a s
 
 
 ```
-const issuanceHex = await stasIssuace.signed(
+const issuanceTx = await stasIssuace.signed(
     issuerPrivateKey, 
     issueData, 
     contractUtxo, 
@@ -447,7 +446,7 @@ const issuanceHex = await stasIssuace.signed(
     protocol
 )
 ```
-After executing the function, you will receive a transaction hexadecimal representation that is now ready to be broadcasted to the miner.
+After executing the function, you will receive a transaction object representation. To convert to hexadecimal simply add "toString()", and is now ready to be broadcasted to the miner.
 
 
 
@@ -475,18 +474,18 @@ To utilize the transfer function, it is necessary to first prepare some UTXOs. S
 Both UTXOs will require private keys to be supplied, although it is possible to use the same private keys for both, if applicable. Finally, you will need to input the destination address string to complete the process.
 
 ```
-const transferHex = await stasTransfer.signed(
+const transferTx = await stasTransfer.signed(
     ownerPrivatekey, 
     stasUtxo, 
     destinationAddress, 
     paymentUtxo, 
     paymentPrivateKey)
 ```
-After executing the function, you will receive a transaction hexadecimal representation that is now ready to be broadcasted to the miner.
+After executing the function, you will receive a transaction object representation. To convert to hexadecimal simply add "toString()", and is now ready to be broadcasted to the miner.
 
 &nbsp;
 ### Split
-Similar to the transfer function, this particular function generates a hexadecimal representation of a transaction that can distribute tokens to multiple addresses at once. It should be noted that this function is only applicable to tokens that have the splittable property set to true. For more details on which token templates possess this attribute, please refer to the STAS features table.
+Similar to the transfer function, this particular function generates transaction that can distribute tokens to multiple addresses at once. It should be noted that this function is only applicable to tokens that have the splittable property set to true. For more details on which token templates possess this attribute, please refer to the STAS features table.
 
 To create a split transaction, we need a STAS UTXO, a fee UTXO, and the private keys linked with these UTXOs. Instead of the destination address required in the transfer function, we need an array that contains all the destination addresses and their corresponding amounts.
 
@@ -510,14 +509,14 @@ const splitDestinations = [
 It should be noted that if the token owner needs to receive change from the STAS UTXO input, it must be included in the splitDestination array. The total amount in the outputs of the array should match the input satoshis amount.
 
 ```
-const splitHex = await stasSplit.signed(
+const splitTx = await stasSplit.signed(
     ownerPrivatekey, 
     stasUtxo, 
     splitDestinations, 
     paymentUtxo, 
     paymentPrivateKey)
 ```
-After executing the function, you will receive a transaction hexadecimal representation that is now ready to be broadcasted to the miner.
+After executing the function, you will receive a transaction object representation. To convert to hexadecimal simply add "toString()", and is now ready to be broadcasted to the miner.
 
 &nbsp;
 
@@ -547,7 +546,7 @@ The previous transaction hex is required as part of the unlocking script to comp
 To create a merge transaction, the following additional parameters are necessary: private keys for both UTXO inputs, a destination address, and the payment UTXO and its corresponding private key.
 
 ```
-const mergeHex = await stasMerge.signed(
+const mergeTx = await stasMerge.signed(
     ownerPrivateKey1,
     stasInput1,
     ownerPrivateKey2,
@@ -557,7 +556,7 @@ const mergeHex = await stasMerge.signed(
     paymentUtxo)
 
 ```
-After executing the function, you will receive a transaction hexadecimal representation that is now ready to be broadcasted to the miner.
+After executing the function, you will receive a transaction object representation. To convert to hexadecimal simply add "toString()", and is now ready to be broadcasted to the miner.
 
 NOTE: It is important to keep in mind that the size of the merge transaction will increase after each subsequent merge transaction due to its design nature. To optimize the transaction size, it is recommended to consider ways to mitigate the compounding effects of the data size. One possible solution is to use interval transfer functions for each UTXO being merged, which resets the previous transaction hexadecimal to the size of a transfer transaction. It is recommended to transfer the UTXO after every two merge transactions as a means of resetting the transaction size before continuing with additional merge transactions.
 
@@ -571,14 +570,14 @@ Token redemption refers to the process of converting the STAS token satoshis bac
 This function will take the typical arguments as follows:
 
 ```
-const redeemHex = await stasRedeem.signed(
+const redeemTx = await stasRedeem.signed(
     ownerPrivateKey,
     stasUtxo,
     paymentUtxo,
     paymentPrivateKey)
 
 ```
-After executing the function, you will receive a transaction hexadecimal representation that is now ready to be broadcasted to the miner.
+After executing the function, you will receive a transaction object representation. To convert to hexadecimal simply add "toString()", and is now ready to be broadcasted to the miner.
 
 The RedeemSplit function is designed to operate similarly to the redeem function, with an added parameter called "splitDestinations". This parameter specifies where the additional outputs of the transaction will be directed, much like the split function. It's worth noting that the total amount designated for split destinations will determine the number of satoshis redeemed from the STAS UTXO input. For example, if the STAS UTXO input contains 10 satoshis and the total output amount in the split destination array is 8, only 2 satoshis will be redeemed. The remaining satoshis will remain locked in STAS tokens and be sent to the new destination address(es).
 
@@ -634,7 +633,7 @@ paymentUtxo: This represents the UTXO that is being used to pay the transaction 
 &nbsp;
 
 ```
-const swapHex = stasAcceptSwap.signed(
+const swapTx = stasAcceptSwap.signed(
     offerTxHex, 
     ownerPrivateKey, 
     makerInputTxHex, 
@@ -649,7 +648,7 @@ const swapHex = stasAcceptSwap.signed(
 &nbsp;
 
 more on additionalOutputs soon...
-After executing the function, you will receive a transaction hexadecimal representation that is now ready to be broadcasted to the miner. The final outcome of the transaction will be that input #0 will transfer ownership to output #1, while input #1 will transfer ownership to output #0, in accordance with the terms of the atomic swap transaction.
+After executing the function, you will receive a transaction object representation. To convert to hexadecimal simply add "toString()", and is now ready to be broadcasted to the miner. The final outcome of the transaction will be that input #0 will transfer ownership to output #1, while input #1 will transfer ownership to output #0, in accordance with the terms of the atomic swap transaction.
 
 &nbsp;
 
@@ -660,7 +659,7 @@ To make this a three step swap we can simply create the offer hex with the unsig
 &nbsp;
 
 ```
-const unsignedOfferHex = await stasCreateSwap.unSigned(
+const unsignedOfferTx = await stasCreateSwap.unSigned(
     ownerPublicKey, 
     utxo, 
     wantedData
@@ -673,14 +672,13 @@ When the unsigned function call is made, the returned object will contain the tr
 An additional argument must be included, which is the complete transaction hexadecimal representation of the taker, which corresponds to input #1 in the unsigned swap hexadecimal.
 
 ```
-const signedSwapHex = await stasSignSwap.signed(
+const signedSwapTx = await stasSignSwap.signed(
     unSignedSwapHex, 
     ownerPrivateKey, 
     takerInputTx
 )
 ```
-After executing the function, you will receive a transaction hexadecimal representation that is now ready to be broadcasted to the miner.
-
+After executing the function, you will receive a transaction object representation. To convert to hexadecimal simply add "toString()", and is now ready to be broadcasted to the miner.
 &nbsp;
 
 ### Additional outputs for atomic swaps
@@ -738,7 +736,7 @@ const data = [
     "Some other plain text string"
 ]
 
-const transferHex = await stasTransfer.signed(
+const transferTx = await stasTransfer.signed(
     ownerPrivatekey, 
     stasUtxo, 
     destinationAddress, 
@@ -760,7 +758,7 @@ const data = [
     "Some other plain text string"
 ]
 
-const transferHex = await stasTransfer.signed(
+const transferTx = await stasTransfer.signed(
     ownerPrivatekey, 
     stasUtxo, 
     destinationAddress, 
@@ -799,7 +797,7 @@ Zero change transaction building is an excellent resource for developers who wis
 To use the zero change model in the functions it requires an arguement boolean set to true. Here is an example in the stasTransfer function 
 
 ```
-const transferHex = await stasTransfer.signed(
+const transferTx = await stasTransfer.signed(
     ownerPrivatekey, 
     stasUtxo, 
     destinationAddress, 
@@ -822,8 +820,8 @@ In this instance, if the change amount surpasses 10 satoshis, an error will be t
 &nbsp;
 
 ### ZeroFee (currently not supported by existing miners)
-Zero fee will create the transaction hex without any payment input UTXO or change output UTXO. This model is currently not supported by any existing miners. 
-
+Zero fee will create the transaction without any payment input UTXO or change output UTXO. This model is currently not supported by any existing miners. 
+hex
 &nbsp;
 
 ### unSigned 
@@ -843,7 +841,7 @@ unsignedData = [{
             sighash  : number - sighash flags for the input,
             publicKeyString : string - public key string of the input
             stas :  boolean - indicating whether the input is stas type or not
-})
+}]
 
 ```
 The unsigned data can be used in conjunction with the BSV library to construct a valid signature for the input(s). 

--- a/lib/stasAcceptSwap.js
+++ b/lib/stasAcceptSwap.js
@@ -173,7 +173,7 @@ async function unSignedFunc(offerTxHex, takerPublicKey, makerInputTxHex, takerIn
         tx: tx,
       };
     } else {
-      return tx.serialize(true);
+      return tx
     }
 }
   

--- a/lib/stasAcceptSwap.js
+++ b/lib/stasAcceptSwap.js
@@ -194,7 +194,7 @@ async function unSignedFunc(offerTxHex, takerPublicKey, makerInputTxHex, takerIn
  * @return {Promise<string>} - will return a promise that contains the signed transaction in hexadecimal format
  */
 async function signedFunc(offerTxHex, ownerPrivateKey, makerInputTxHex, takerInputTxHex, takerVout, paymentPrivateKey, paymentUtxo, additionalOutputs, data, isZeroChange, txCost, feeEstimateCall) {
-    return await unSignedFunc(offerTxHex, bsv.PublicKey.fromPrivateKey(ownerPrivateKey).toString('hex'), makerInputTxHex, takerInputTxHex, takerVout, bsv.PublicKey.fromPrivateKey(paymentPrivateKey).toString('hex'), paymentUtxo, additionalOutputs, data, isZeroChange, ownerPrivateKey, paymentPrivateKey, txCost, feeEstimateCall);
+    return await unSignedFunc(offerTxHex, ownerPrivateKey.publicKey.toString('hex'), makerInputTxHex, takerInputTxHex, takerVout, paymentPrivateKey.publicKey.toString('hex'), paymentUtxo, additionalOutputs, data, isZeroChange, ownerPrivateKey, paymentPrivateKey, txCost, feeEstimateCall);
 }
   
 /**

--- a/lib/stasContract.js
+++ b/lib/stasContract.js
@@ -95,7 +95,7 @@ async function unSignedFunc(issuerPublicKey, contractUtxo, paymentPublicKey, pay
       tx: tx,
     };
   } else {
-    return tx.serialize(true);
+    return tx
   }
 }
 

--- a/lib/stasContract.js
+++ b/lib/stasContract.js
@@ -113,7 +113,7 @@ async function unSignedFunc(issuerPublicKey, contractUtxo, paymentPublicKey, pay
  * @return {Promise<string>} - will return a promise that contains the signed transaction hexadecimal
  */
 async function signedFunc(issuerPrivateKey, contractUtxo, paymentUtxo, paymentPrivateKey, tokenSchema, tokenSatoshis, isZeroChange = false, txCost, feeEstimateCall) {
-  return await unSignedFunc(bsv.PublicKey.fromPrivateKey(issuerPrivateKey).toString('hex'), contractUtxo, bsv.PublicKey.fromPrivateKey(paymentPrivateKey).toString('hex'), paymentUtxo, tokenSchema, tokenSatoshis, isZeroChange, issuerPrivateKey, paymentPrivateKey, txCost, feeEstimateCall);
+  return await unSignedFunc(issuerPrivateKey.publicKey.toString('hex'), contractUtxo, paymentPrivateKey.publicKey.toString('hex'), paymentUtxo, tokenSchema, tokenSatoshis, isZeroChange, issuerPrivateKey, paymentPrivateKey, txCost, feeEstimateCall);
 }
 
 /**

--- a/lib/stasCreateSwap.js
+++ b/lib/stasCreateSwap.js
@@ -34,7 +34,7 @@ async function unSigned(ownerPublicKey, utxo, wantedData, ownerPrivateKey) {
   
     if (ownerPrivateKey) {
       tx.inputs[0].setScript(bsv.Script.fromASM(`${bsv.Transaction.sighash.sign(tx, ownerPrivateKey, utility.SIGHASH_SINGLE, 0, tx.inputs[0].output._script, tx.inputs[0].output._satoshisBN, utility.FLAGS).toTxFormat().toString('hex')} ${ownerPublicKey}`));
-      return tx.serialize(true);
+      return tx
     } else {
       unsignedData.push({inputIndex: 0, satoshis: tx.inputs[0].output._satoshisBN, script: tx.inputs[0].output._script, sighash: utility.SIGHASH_SINGLE, publicKeyString: ownerPublicKey, flags: utility.FLAGS, stas: false});
       return {

--- a/lib/stasCreateSwap.js
+++ b/lib/stasCreateSwap.js
@@ -52,7 +52,7 @@ async function unSigned(ownerPublicKey, utxo, wantedData, ownerPrivateKey) {
  * @return {Promise<string>} - will return a promise that contains the signed transaction in hexadecimal format
  */
 async function signed(ownerPrivateKey, utxo, wantedData) {
-    return await unSigned(bsv.PublicKey.fromPrivateKey(ownerPrivateKey).toString(), utxo, wantedData, ownerPrivateKey);
+    return await unSigned(ownerPrivateKey.publicKey.toString('hex'), utxo, wantedData, ownerPrivateKey);
 }
 
 module.exports =  {signed, unSigned}

--- a/lib/stasFeeEstimates.js
+++ b/lib/stasFeeEstimates.js
@@ -23,7 +23,7 @@ class FeeEstimates {
       this.utility = utility;
       this.txCost = 1;
       this.stasUtils = stasUtils;
-      this.signInputAmount = 30;
+      this.signInputAmount = 2;
     }
   
     async buildSplitDestinations(numberOfSplits, totalTokenUtxoSatoshis) {

--- a/lib/stasIssuance.js
+++ b/lib/stasIssuance.js
@@ -101,7 +101,7 @@ async function unSignedFunc(issuerPublicKey, contractUtxo, paymentPublicKey, pay
  * @return {Promise<string>} - will return a promise that contains the signed transaction in hexadecimal format
  */
 async function signedFunc(issuerPrivateKey, issueData, contractUtxo, paymentUtxo, paymentPrivateKey, isSplittable, symbol, protocol, isZeroChange = false, txCost, feeEstimateCall) {
-  return unSignedFunc(bsv.PublicKey.fromPrivateKey(issuerPrivateKey), contractUtxo, bsv.PublicKey.fromPrivateKey(paymentPrivateKey), paymentUtxo, issueData, isSplittable, symbol, protocol, isZeroChange, issuerPrivateKey, paymentPrivateKey, txCost, feeEstimateCall);
+  return unSignedFunc(issuerPrivateKey.publicKey.toString('hex'), contractUtxo, paymentPrivateKey.publicKey.toString('hex'), paymentUtxo, issueData, isSplittable, symbol, protocol, isZeroChange, issuerPrivateKey, paymentPrivateKey, txCost, feeEstimateCall);
 }
 
 /**

--- a/lib/stasIssuance.js
+++ b/lib/stasIssuance.js
@@ -81,7 +81,7 @@ async function unSignedFunc(issuerPublicKey, contractUtxo, paymentPublicKey, pay
       tx: tx,
     };
   } else {
-    return tx.serialize(true);
+    return tx
   }
 }
 

--- a/lib/stasMerge.js
+++ b/lib/stasMerge.js
@@ -133,7 +133,7 @@ async function unSignedFunc(ownerPublicKey1, stasInput1, ownerPublicKey2, stasIn
       tx: tx,
     };
   } else {
-    return tx.serialize(true);
+    return tx
   }
 }
 

--- a/lib/stasMerge.js
+++ b/lib/stasMerge.js
@@ -153,7 +153,7 @@ async function unSignedFunc(ownerPublicKey1, stasInput1, ownerPublicKey2, stasIn
  * @return {Promise<string>} - will return a promise that contains the signed transaction in hexadecimal format
  */
 async function signedFunc(ownerPrivateKey1, stasInput1, ownerPrivateKey2, stasInput2, destinationAddr, paymentPrivateKey, paymentUtxo, data, isZeroChange, txCost, feeEstimateCall) {
-  return await unSignedFunc(bsv.PublicKey.fromPrivateKey(ownerPrivateKey1).toString(), stasInput1, bsv.PublicKey.fromPrivateKey(ownerPrivateKey2).toString(), stasInput2, destinationAddr, bsv.PublicKey.fromPrivateKey(paymentPrivateKey).toString(), paymentUtxo, data, isZeroChange, ownerPrivateKey1, ownerPrivateKey2, paymentPrivateKey, txCost, feeEstimateCall);
+  return await unSignedFunc(ownerPrivateKey1.publicKey.toString('hex'), stasInput1, ownerPrivateKey2.publicKey.toString('hex'), stasInput2, destinationAddr, paymentPrivateKey.publicKey.toString('hex'), paymentUtxo, data, isZeroChange, ownerPrivateKey1, ownerPrivateKey2, paymentPrivateKey, txCost, feeEstimateCall);
 }
 
 /**

--- a/lib/stasMergeSplit.js
+++ b/lib/stasMergeSplit.js
@@ -143,7 +143,7 @@ async function unSignedFunc(ownerPublicKey1, stasInput1, ownerPublicKey2, stasIn
       tx: tx,
     };
   } else {
-    return tx.serialize(true);
+    return tx
   }
 }
 

--- a/lib/stasMergeSplit.js
+++ b/lib/stasMergeSplit.js
@@ -163,7 +163,7 @@ async function unSignedFunc(ownerPublicKey1, stasInput1, ownerPublicKey2, stasIn
  * @return {Promise<string>} - will return a promise that contains the signed transaction in hexadecimal format
  */
 async function signedFunc(ownerPrivateKey1, stasInput1, ownerPrivateKey2, stasInput2, splitDestinations, paymentPrivateKey, paymentUtxo, data, isZeroChange, txCost, feeEstimateCall) {
-  return await unSignedFunc(bsv.PublicKey.fromPrivateKey(ownerPrivateKey1).toString(), stasInput1, bsv.PublicKey.fromPrivateKey(ownerPrivateKey2).toString(), stasInput2, splitDestinations, bsv.PublicKey.fromPrivateKey(paymentPrivateKey).toString(), paymentUtxo, data, isZeroChange, ownerPrivateKey1, ownerPrivateKey2, paymentPrivateKey, txCost, feeEstimateCall);
+  return await unSignedFunc(ownerPrivateKey1.publicKey.toString('hex'), stasInput1, ownerPrivateKey2.publicKey.toString('hex'), stasInput2, splitDestinations, paymentPrivateKey.publicKey.toString('hex'), paymentUtxo, data, isZeroChange, ownerPrivateKey1, ownerPrivateKey2, paymentPrivateKey, txCost, feeEstimateCall);
 }
 
 /**

--- a/lib/stasRedeem.js
+++ b/lib/stasRedeem.js
@@ -96,7 +96,7 @@ async function unSignedFunc(ownerPublicKey, stasUtxo, paymentPublicKey, paymentU
         tx: tx,
       };
     } else {
-      return tx.serialize(true);
+      return tx
     }
 }
   

--- a/lib/stasRedeem.js
+++ b/lib/stasRedeem.js
@@ -113,7 +113,7 @@ async function unSignedFunc(ownerPublicKey, stasUtxo, paymentPublicKey, paymentU
  * @return {Promise<string>} - will return a promise that contains the signed transaction in hexadecimal format
  */
 function signedFunc(ownerPrivateKey, stasUtxo, paymentUtxo, paymentPrivateKey, data, isZeroChange, txCost, feeEstimateCall ) {
-    return unSignedFunc(bsv.PublicKey.fromPrivateKey(ownerPrivateKey).toString(), stasUtxo, bsv.PublicKey.fromPrivateKey(paymentPrivateKey).toString(), paymentUtxo, data, isZeroChange, ownerPrivateKey, paymentPrivateKey, txCost, feeEstimateCall);
+    return unSignedFunc(ownerPrivateKey.publicKey.toString('hex'), stasUtxo, paymentPrivateKey.publicKey.toString('hex'), paymentUtxo, data, isZeroChange, ownerPrivateKey, paymentPrivateKey, txCost, feeEstimateCall);
 }
   
 /**

--- a/lib/stasRedeemSplit.js
+++ b/lib/stasRedeemSplit.js
@@ -130,7 +130,7 @@ async function unSignedFunc(ownerPublicKey, stasUtxo, paymentPublicKey, paymentU
  * @return {Promise<string>} - will return a promise that contains the signed transaction in hexadecimal format
  */
 async function signedFunc(ownerPrivateKey, stasUtxo, splitDestinations, paymentUtxo, paymentPrivateKey, data, isZeroChange, txCost, feeEstimateCall) {
-  return await unSignedFunc(bsv.PublicKey.fromPrivateKey(ownerPrivateKey).toString(), stasUtxo, bsv.PublicKey.fromPrivateKey(paymentPrivateKey).toString(), paymentUtxo, splitDestinations, data, isZeroChange, ownerPrivateKey, paymentPrivateKey, txCost, feeEstimateCall);
+  return await unSignedFunc(ownerPrivateKey.publicKey.toString('hex'), stasUtxo, paymentPrivateKey.publicKey.toString('hex'), paymentUtxo, splitDestinations, data, isZeroChange, ownerPrivateKey, paymentPrivateKey, txCost, feeEstimateCall);
 }
 
 /**

--- a/lib/stasRedeemSplit.js
+++ b/lib/stasRedeemSplit.js
@@ -112,7 +112,7 @@ async function unSignedFunc(ownerPublicKey, stasUtxo, paymentPublicKey, paymentU
       tx: tx,
     };
   } else {
-    return tx.serialize(true);
+    return tx
   }
 }
 

--- a/lib/stasSignSwap.js
+++ b/lib/stasSignSwap.js
@@ -62,7 +62,7 @@ async function unSigned(unSignedSwapHex, takerInputTxHex, ownerPublicKey, isZero
     if (ownerPrivateKey) {
       ownerUnlockingScript += `${bsv.Transaction.Sighash.sign(tx, ownerPrivateKey, utility.SIGHASH, 0, bsv.Script.fromHex(ownerScript), new BN(tx.outputs[1].satoshis), utility.FLAGS).toTxFormat().toString('hex')} ${ownerPublicKey}`;
       tx.inputs[0].setScript(bsv.Script.fromASM(ownerUnlockingScript));
-      return tx.serialize(true);
+      return tx
     } else {
       tx.inputs[0].setScript(bsv.Script.fromASM(outputsUnlockingScriptPart));
       unsignedData.push({inputIndex: 0, satoshis: new BN(tx.outputs[1].satoshis), script: bsv.Script.fromHex(ownerScript), sighash: utility.SIGHASH, publicKeyString: ownerPublicKey, flags: utility.FLAGS, stas: true});

--- a/lib/stasSignSwap.js
+++ b/lib/stasSignSwap.js
@@ -82,7 +82,7 @@ async function unSigned(unSignedSwapHex, takerInputTxHex, ownerPublicKey, isZero
  * @return {Promise<string>} - will return a promise that contains the signed transaction in hexadecimal format
  */
 async function signed(unSignedSwapHex, ownerPrivateKey, takerInputTx, isZeroChange) {
-    return await unSigned(unSignedSwapHex, takerInputTx, bsv.PublicKey.fromPrivateKey(ownerPrivateKey).toString(), isZeroChange, ownerPrivateKey);
+    return await unSigned(unSignedSwapHex, takerInputTx, ownerPrivateKey.publicKey.toString('hex'), isZeroChange, ownerPrivateKey);
 }
 
 module.exports =  {signed, unSigned}

--- a/lib/stasSplit.js
+++ b/lib/stasSplit.js
@@ -94,7 +94,7 @@ async function unSignedFunc(ownerPublicKey, stasUtxo, paymentPublicKey, paymentU
       tx: tx,
     };
   } else {
-    return tx.serialize(true);
+    return tx
   }
 }
 

--- a/lib/stasSplit.js
+++ b/lib/stasSplit.js
@@ -112,7 +112,7 @@ async function unSignedFunc(ownerPublicKey, stasUtxo, paymentPublicKey, paymentU
  * @return {Promise<string>} - will return a promise that contains the signed transaction in hexadecimal format
  */
 async function signedFunc(ownerPrivateKey, stasUtxo, splitDestinations, paymentUtxo, paymentPrivateKey, data, isZeroChange, txCost, feeEstimateCall) {
-  return await unSignedFunc(bsv.PublicKey.fromPrivateKey(ownerPrivateKey).toString(), stasUtxo, bsv.PublicKey.fromPrivateKey(paymentPrivateKey).toString(), paymentUtxo, splitDestinations, data, isZeroChange, ownerPrivateKey, paymentPrivateKey, txCost, feeEstimateCall);
+  return await unSignedFunc(ownerPrivateKey.publicKey.toString('hex'), stasUtxo, paymentPrivateKey.publicKey.toString('hex'), paymentUtxo, splitDestinations, data, isZeroChange, ownerPrivateKey, paymentPrivateKey, txCost, feeEstimateCall);
 }
 
 /**

--- a/lib/stasTransfer.js
+++ b/lib/stasTransfer.js
@@ -120,7 +120,7 @@ async function unSignedFunc(ownerPublicKey, stasUtxo, destinationAddress, paymen
  * @return {Promise<string>} - will return a promise that contains the signed transaction in hexadecimal format
  */
 async function signedFunc(ownerPrivatekey, stasUtxo, destinationAddress, paymentUtxo, paymentPrivateKey, data, isZeroChange, txCost, feeEstimateCall) {
-  return await unSignedFunc(bsv.PublicKey.fromPrivateKey(ownerPrivatekey).toString(), stasUtxo, destinationAddress, paymentUtxo, bsv.PublicKey.fromPrivateKey(paymentPrivateKey).toString(), data, isZeroChange, ownerPrivatekey, paymentPrivateKey, txCost, feeEstimateCall);
+  return await unSignedFunc(ownerPrivatekey.publicKey.toString('hex'), stasUtxo, destinationAddress, paymentUtxo, paymentPrivateKey.publicKey.toString('hex'), data, isZeroChange, ownerPrivatekey, paymentPrivateKey, txCost, feeEstimateCall);
 }
 
 /**

--- a/lib/stasTransfer.js
+++ b/lib/stasTransfer.js
@@ -102,7 +102,7 @@ async function unSignedFunc(ownerPublicKey, stasUtxo, destinationAddress, paymen
       tx: tx,
     };
   } else {
-    return tx.serialize(true);
+    return tx
   }
 }
 

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -62,7 +62,7 @@ class Utility {
         privateKey = privateKey.toString();
       }
       privateKey = bsv.PrivateKey.fromString(privateKey);
-      return bsv.PublicKey.fromPrivateKey(privateKey).toString('hex');
+      return privateKey.publicKey.toString('hex');
     }
   
     /**

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -22,9 +22,9 @@ class Utility {
        * @return {string} - hex string format
        */
     int2SM(num) {
-      const n = new BN(num);
-      const m = n.toSM({endian: 'little'} );
-      return m.toString('hex');
+      const n = bsv.crypto.BN.fromNumber(num)
+      const eg = n.toSM({ endian: 'little' }).toString('hex')
+      return eg
     }
   
     /**
@@ -36,9 +36,7 @@ class Utility {
       if (num < 17) {
         return `OP_${num}`;
       } else {
-        const bn = new BN(num);
-        const smBuffer = bn.toSM({endian: 'little'});
-        return smBuffer.toString('hex');
+        return this.int2SM(num)
       }
     }
   

--- a/tests/instantMint.js
+++ b/tests/instantMint.js
@@ -36,19 +36,19 @@ const instantMint = async () => {
   
     // Create contract TX
     const contractHex = await stasContract.signed(testTools.issuerPrivateKey, testTools.issuerUtxo, testTools.contractFeeUtxo, testTools.privateKey, tokenSchemaTemplate, 10);
-    const contractTxResponse = await testTools.broadcast(contractHex);
+    const contractTxResponse = await testTools.broadcast(contractHex.toString());
     console.log('Contract Txid: ', contractTxResponse.data);
     const contractUtxo = utility.getUtxoFromTx(contractHex, 0);
   
     // Create issue TX
     const issueHex = await stasIssuance.signed(testTools.issuerPrivateKey, issueData, contractUtxo, testTools.issueFeeUtxo, testTools.privateKey, true, tokenSchemaTemplate.symbol, 'STAS-20');
-    const issueTxResponse = await testTools.broadcast(issueHex);
+    const issueTxResponse = await testTools.broadcast(issueHex.toString());
     console.log('Issue Txid: ', issueTxResponse.data);
     const tokenUtxoFromIssuance = utility.getUtxoFromTx(issueHex, 0);
   
     // Create redeem TX
     const redeemHex = await stasRedeem.signed(testTools.issuerPrivateKey, tokenUtxoFromIssuance, testTools.redeemFeeUtxo, testTools.privateKey );
-    const redeemTxResponse = await testTools.broadcast(redeemHex);
+    const redeemTxResponse = await testTools.broadcast(redeemHex.toString());
     console.log('Redeem Txid: ', redeemTxResponse.data);
   
     console.log('Instant Mint Example Completed');

--- a/tests/nonBroadcastFullCycleTest.js
+++ b/tests/nonBroadcastFullCycleTest.js
@@ -42,32 +42,32 @@ const fullCycleTestNonBroadcast = async () => {
   console.log('Start Full Cycle Non Broadcast Test...');
 
   // Create a contract transaction of the token. Will create a token contract for a supply of 10 tokens.
-  const contractHex = await stasContract.signed(issuerPrivateKey, utxoTemplateForContract, utxoTemplateForFees, paymentPrivateKey, tokenSchemaTemplate, 10);
-  console.log('Contract Transaction Hex: ', contractHex.toString());
-  const contractUtxo = utility.getUtxoFromTx(contractHex, 0);
+  const contractTx = await stasContract.signed(issuerPrivateKey, utxoTemplateForContract, utxoTemplateForFees, paymentPrivateKey, tokenSchemaTemplate, 10);
+  console.log('Contract Transaction Hex: ', contractTx.toString());
+  const contractUtxo = utility.getUtxoFromTx(contractTx, 0);
 
 
   // Issue the token from the contract UTXO. This will be a STAS-20 token type.
-  const issueHex = await stasIssuance.signed(issuerPrivateKey, issueData, contractUtxo, utxoTemplateForFees, paymentPrivateKey, true, tokenSchemaTemplate.symbol, 'STAS-20');
-  console.log('Issue Transaction Hex: ', issueHex.toString());
-  const tokenUtxoFromIssuance = utility.getUtxoFromTx(issueHex, 0);
+  const issueTx = await stasIssuance.signed(issuerPrivateKey, issueData, contractUtxo, utxoTemplateForFees, paymentPrivateKey, true, tokenSchemaTemplate.symbol, 'STAS-20');
+  console.log('Issue Transaction Hex: ', issueTx.toString());
+  const tokenUtxoFromIssuance = utility.getUtxoFromTx(issueTx, 0);
 
 
   // Transfer the token to the same owner address.
-  const transferHex1 = await stasTransfer.signed(tokenOwnerPrivateKey, tokenUtxoFromIssuance, tokenOwnerAddress, utxoTemplateForFees, paymentPrivateKey );
-  console.log('Transfer1 Transaction Hex: ', transferHex1.toString());
-  const tokenUtxoFromTransfer1 = utility.getUtxoFromTx(transferHex1, 0);
+  const transferTx1 = await stasTransfer.signed(tokenOwnerPrivateKey, tokenUtxoFromIssuance, tokenOwnerAddress, utxoTemplateForFees, paymentPrivateKey );
+  console.log('Transfer1 Transaction Hex: ', transferTx1.toString());
+  const tokenUtxoFromTransfer1 = utility.getUtxoFromTx(transferTx1, 0);
 
 
   // Split the token into two UTXOs of 5 satoshis each
   const splitDestinationsForSplitTx1 = [{address: tokenOwnerAddress, satoshis: 5}, {address: tokenOwnerAddress, satoshis: 5}];
-  const splitHex1 = await stasSplit.signed(tokenOwnerPrivateKey, tokenUtxoFromTransfer1, splitDestinationsForSplitTx1, utxoTemplateForFees, paymentPrivateKey );
-  console.log('Split1 Transaction Hex: ', splitHex1.toString());
+  const splitTx1 = await stasSplit.signed(tokenOwnerPrivateKey, tokenUtxoFromTransfer1, splitDestinationsForSplitTx1, utxoTemplateForFees, paymentPrivateKey );
+  console.log('Split1 Transaction Hex: ', splitTx1.toString());
 
 
   // Merge the two 5 satoshi tokens back into a single UTXO. For this we require the whole previous transaction hex and vout value for both STAS UTXO inputs.
-  const stasData1 = {txHex: splitHex1, vout: 0};
-  const stasData2 = {txHex: splitHex1, vout: 1};
+  const stasData1 = {txHex: splitTx1.toString(), vout: 0};
+  const stasData2 = {txHex: splitTx1.toString(), vout: 1};
   const mergeHex = await stasMerge.signed(tokenOwnerPrivateKey, stasData1, tokenOwnerPrivateKey, stasData2, tokenOwnerAddress, paymentPrivateKey, utxoTemplateForFees);
   console.log('Merge Transaction Hex: ', mergeHex.toString());
   const tokenUtxoFromMergeTx = utility.getUtxoFromTx(mergeHex, 0);
@@ -75,13 +75,13 @@ const fullCycleTestNonBroadcast = async () => {
 
   // Split the token into two UTXOs one of 9 satoshis and one of 1 satoshi
   const splitDestinationsForSplitTx2 = [{address: tokenOwnerAddress, satoshis: 9}, {address: tokenOwnerAddress, satoshis: 1}];
-  const splitHex2 = await stasSplit.signed(tokenOwnerPrivateKey, tokenUtxoFromMergeTx, splitDestinationsForSplitTx2, utxoTemplateForFees, paymentPrivateKey );
-  console.log('Split2 Transaction Hex: ', splitHex2.toString());
+  const splitTx2 = await stasSplit.signed(tokenOwnerPrivateKey, tokenUtxoFromMergeTx, splitDestinationsForSplitTx2, utxoTemplateForFees, paymentPrivateKey );
+  console.log('Split2 Transaction Hex: ', splitTx2.toString());
 
 
   // MergeSplit will take two UTXO inputs and then allow it to be split into more than one output. We will merge the UTXOs of 9 satoshi and 1 satoshis and create two new outputs with 2 satoshis and 8 satoshis
-  const stasData3 = {txHex: splitHex2, vout: 0};
-  const stasData4 = {txHex: splitHex2, vout: 1};
+  const stasData3 = {txHex: splitTx2.toString(), vout: 0};
+  const stasData4 = {txHex: splitTx2.toString(), vout: 1};
   const splitDestinationsForMergeSplitTx = [{address: tokenOwnerAddress, satoshis: 2}, {address: tokenOwnerAddress, satoshis: 8}];
   const mergeSplitHex = await stasMergeSplit.signed(tokenOwnerPrivateKey, stasData3, tokenOwnerPrivateKey, stasData4, splitDestinationsForMergeSplitTx, paymentPrivateKey, utxoTemplateForFees);
   console.log('MergeSplit Transaction Hex: ', mergeSplitHex.toString());
@@ -89,9 +89,9 @@ const fullCycleTestNonBroadcast = async () => {
 
 
   // We will transfer the first token UTXO from the mergeSplit transaction to the same owner address
-  const transferHex2 = await stasTransfer.signed(tokenOwnerPrivateKey, tokenUtxosFromMergeSplitTx[0], tokenOwnerAddress, utxoTemplateForFees, paymentPrivateKey);
-  console.log('Transfer2 Transaction Hex: ', transferHex2.toString());
-  const tokenUtxoFromTransfer2 = utility.getUtxoFromTx(transferHex2, 0);
+  const transferTx2 = await stasTransfer.signed(tokenOwnerPrivateKey, tokenUtxosFromMergeSplitTx[0], tokenOwnerAddress, utxoTemplateForFees, paymentPrivateKey);
+  console.log('Transfer2 Transaction Hex: ', transferTx2.toString());
+  const tokenUtxoFromTransfer2 = utility.getUtxoFromTx(transferTx2, 0);
 
 
   // We will transfer the second token UTXO from the mergeSplit transaction to the same owner address
@@ -101,42 +101,42 @@ const fullCycleTestNonBroadcast = async () => {
 
 
   // Here we will create an offer transaction hex to be used in an atomic swap. For this we will just swap one STAS token UTXO for another.
-  // This example will take the STAS UTXO from the transferHex2 transaction and create an offer to swap it for the transactionHex3 transaction STAS UTXO
+  // This example will take the STAS UTXO from the transferTx2 transaction and create an offer to swap it for the transactionHex3 transaction STAS UTXO
   const wantedDataForCreateSwap = {satoshis: tokenUtxoFromTransfer3.satoshis, script: tokenUtxoFromTransfer3.script};
-  const offerHex = await stasCreateSwap.signed(tokenOwnerPrivateKey, tokenUtxoFromTransfer2, wantedDataForCreateSwap);
-  console.log('Offer Transaction Hex: ', offerHex.toString());
+  const offerTx = await stasCreateSwap.signed(tokenOwnerPrivateKey, tokenUtxoFromTransfer2, wantedDataForCreateSwap);
+  console.log('Offer Transaction Hex: ', offerTx.toString());
 
 
   // We will now complete the swap by adding in all remaining parameters required to call the stasAcceptSwap function
-  const swapHex = await stasAcceptSwap.signed(offerHex, tokenOwnerPrivateKey, transferHex2, transferHex3, tokenUtxoFromTransfer3.vout, paymentPrivateKey, utxoTemplateForFees);
-  console.log('Swap Transaction Hex: ', swapHex.toString());
+  const swapTx = await stasAcceptSwap.signed(offerTx, tokenOwnerPrivateKey, transferTx2, transferHex3, tokenUtxoFromTransfer3.vout, paymentPrivateKey, utxoTemplateForFees);
+  console.log('Swap Transaction Hex: ', swapTx.toString());
 
 
   // Here we will now merge the two STAS UTXOs from the atomic swap into a single 10 satoshi STAS UTXO
-  const stasData5 = {txHex: swapHex, vout: 0};
-  const stasData6 = {txHex: swapHex, vout: 1};
-  const mergeHex2 = await stasMerge.signed(tokenOwnerPrivateKey, stasData5, tokenOwnerPrivateKey, stasData6, tokenOwnerAddress, paymentPrivateKey, utxoTemplateForFees);
-  console.log('Merge2 Transaction Hex: ', mergeHex2.toString());
-  const tokenUtxoFromMergeTx2 = utility.getUtxoFromTx(mergeHex2, 0);
+  const stasData5 = {txHex: swapTx.toString(), vout: 0};
+  const stasData6 = {txHex: swapTx.toString(), vout: 1};
+  const mergeTx2 = await stasMerge.signed(tokenOwnerPrivateKey, stasData5, tokenOwnerPrivateKey, stasData6, tokenOwnerAddress, paymentPrivateKey, utxoTemplateForFees);
+  console.log('Merge2 Transaction Hex: ', mergeTx2.toString());
+  const tokenUtxoFromMergeTx2 = utility.getUtxoFromTx(mergeTx2, 0);
 
 
   // Here we are now transferring the token to the issuer address. This is required for the STAS-20 token as only the issuer is allowed to redeem the token.
-  const transferHex4 = await stasTransfer.signed(tokenOwnerPrivateKey, tokenUtxoFromMergeTx2, issuerAddress, utxoTemplateForFees, paymentPrivateKey);
-  console.log('Transfer4 Transaction Hex: ', transferHex4.toString());
-  const tokenUtxoFromTransfer4 = utility.getUtxoFromTx(transferHex4, 0);
+  const transferTx4 = await stasTransfer.signed(tokenOwnerPrivateKey, tokenUtxoFromMergeTx2, issuerAddress, utxoTemplateForFees, paymentPrivateKey);
+  console.log('Transfer4 Transaction Hex: ', transferTx4.toString());
+  const tokenUtxoFromTransfer4 = utility.getUtxoFromTx(transferTx4, 0);
 
 
   // Now we will create the redeem split transaction. This allows for only a portion of the UTXO to be redeemed and the remainder will go to other outputs as STAS TOKENS. In this case we will redeem 5 of the 10 tokens and leave 5 as a remainder.
   // Note that the first output will always be the p2pkh redemption output which will be the conversion back to native satoshis
   const splitDestinationsForRedeemSplit = [{address: issuerAddress, satoshis: 5}];
-  const redeemSplitHex = await stasRedeemSplit.signed(issuerPrivateKey, tokenUtxoFromTransfer4, splitDestinationsForRedeemSplit, utxoTemplateForFees, paymentPrivateKey);
-  console.log('RedeemSplit Transaction Hex: ', redeemSplitHex.toString());
-  const tokenUtxosFromRedeemSplitTx = utility.getUtxoFromTx(redeemSplitHex, 1);
+  const redeemSplitTx = await stasRedeemSplit.signed(issuerPrivateKey, tokenUtxoFromTransfer4, splitDestinationsForRedeemSplit, utxoTemplateForFees, paymentPrivateKey);
+  console.log('RedeemSplit Transaction Hex: ', redeemSplitTx.toString());
+  const tokenUtxosFromRedeemSplitTx = utility.getUtxoFromTx(redeemSplitTx, 1);
 
 
   // Now we will redeem the final STAS UTXO back to native satoshis which completes the full cycle.
-  const redeemHex = await stasRedeem.signed(issuerPrivateKey, tokenUtxosFromRedeemSplitTx, utxoTemplateForFees, paymentPrivateKey);
-  console.log('Redeem Transaction Hex: ', redeemHex.toString());
+  const redeemTx = await stasRedeem.signed(issuerPrivateKey, tokenUtxosFromRedeemSplitTx, utxoTemplateForFees, paymentPrivateKey);
+  console.log('Redeem Transaction Hex: ', redeemTx.toString());
 
   console.log('Full Cycle Non Broadcast Test Completed');
 };

--- a/tests/nonBroadcastFullCycleTest.js
+++ b/tests/nonBroadcastFullCycleTest.js
@@ -43,40 +43,40 @@ const fullCycleTestNonBroadcast = async () => {
 
   // Create a contract transaction of the token. Will create a token contract for a supply of 10 tokens.
   const contractHex = await stasContract.signed(issuerPrivateKey, utxoTemplateForContract, utxoTemplateForFees, paymentPrivateKey, tokenSchemaTemplate, 10);
-  console.log('Contract Transaction Hex: ', contractHex);
+  console.log('Contract Transaction Hex: ', contractHex.toString());
   const contractUtxo = utility.getUtxoFromTx(contractHex, 0);
 
 
   // Issue the token from the contract UTXO. This will be a STAS-20 token type.
   const issueHex = await stasIssuance.signed(issuerPrivateKey, issueData, contractUtxo, utxoTemplateForFees, paymentPrivateKey, true, tokenSchemaTemplate.symbol, 'STAS-20');
-  console.log('Issue Transaction Hex: ', issueHex);
+  console.log('Issue Transaction Hex: ', issueHex.toString());
   const tokenUtxoFromIssuance = utility.getUtxoFromTx(issueHex, 0);
 
 
   // Transfer the token to the same owner address.
   const transferHex1 = await stasTransfer.signed(tokenOwnerPrivateKey, tokenUtxoFromIssuance, tokenOwnerAddress, utxoTemplateForFees, paymentPrivateKey );
-  console.log('Transfer1 Transaction Hex: ', transferHex1);
+  console.log('Transfer1 Transaction Hex: ', transferHex1.toString());
   const tokenUtxoFromTransfer1 = utility.getUtxoFromTx(transferHex1, 0);
 
 
   // Split the token into two UTXOs of 5 satoshis each
   const splitDestinationsForSplitTx1 = [{address: tokenOwnerAddress, satoshis: 5}, {address: tokenOwnerAddress, satoshis: 5}];
   const splitHex1 = await stasSplit.signed(tokenOwnerPrivateKey, tokenUtxoFromTransfer1, splitDestinationsForSplitTx1, utxoTemplateForFees, paymentPrivateKey );
-  console.log('Split1 Transaction Hex: ', splitHex1);
+  console.log('Split1 Transaction Hex: ', splitHex1.toString());
 
 
   // Merge the two 5 satoshi tokens back into a single UTXO. For this we require the whole previous transaction hex and vout value for both STAS UTXO inputs.
   const stasData1 = {txHex: splitHex1, vout: 0};
   const stasData2 = {txHex: splitHex1, vout: 1};
   const mergeHex = await stasMerge.signed(tokenOwnerPrivateKey, stasData1, tokenOwnerPrivateKey, stasData2, tokenOwnerAddress, paymentPrivateKey, utxoTemplateForFees);
-  console.log('Merge Transaction Hex: ', mergeHex);
+  console.log('Merge Transaction Hex: ', mergeHex.toString());
   const tokenUtxoFromMergeTx = utility.getUtxoFromTx(mergeHex, 0);
 
 
   // Split the token into two UTXOs one of 9 satoshis and one of 1 satoshi
   const splitDestinationsForSplitTx2 = [{address: tokenOwnerAddress, satoshis: 9}, {address: tokenOwnerAddress, satoshis: 1}];
   const splitHex2 = await stasSplit.signed(tokenOwnerPrivateKey, tokenUtxoFromMergeTx, splitDestinationsForSplitTx2, utxoTemplateForFees, paymentPrivateKey );
-  console.log('Split2 Transaction Hex: ', splitHex2);
+  console.log('Split2 Transaction Hex: ', splitHex2.toString());
 
 
   // MergeSplit will take two UTXO inputs and then allow it to be split into more than one output. We will merge the UTXOs of 9 satoshi and 1 satoshis and create two new outputs with 2 satoshis and 8 satoshis
@@ -84,19 +84,19 @@ const fullCycleTestNonBroadcast = async () => {
   const stasData4 = {txHex: splitHex2, vout: 1};
   const splitDestinationsForMergeSplitTx = [{address: tokenOwnerAddress, satoshis: 2}, {address: tokenOwnerAddress, satoshis: 8}];
   const mergeSplitHex = await stasMergeSplit.signed(tokenOwnerPrivateKey, stasData3, tokenOwnerPrivateKey, stasData4, splitDestinationsForMergeSplitTx, paymentPrivateKey, utxoTemplateForFees);
-  console.log('MergeSplit Transaction Hex: ', mergeSplitHex);
+  console.log('MergeSplit Transaction Hex: ', mergeSplitHex.toString());
   const tokenUtxosFromMergeSplitTx = [utility.getUtxoFromTx(mergeSplitHex, 0), utility.getUtxoFromTx(mergeSplitHex, 1)];
 
 
   // We will transfer the first token UTXO from the mergeSplit transaction to the same owner address
   const transferHex2 = await stasTransfer.signed(tokenOwnerPrivateKey, tokenUtxosFromMergeSplitTx[0], tokenOwnerAddress, utxoTemplateForFees, paymentPrivateKey);
-  console.log('Transfer2 Transaction Hex: ', transferHex2);
+  console.log('Transfer2 Transaction Hex: ', transferHex2.toString());
   const tokenUtxoFromTransfer2 = utility.getUtxoFromTx(transferHex2, 0);
 
 
   // We will transfer the second token UTXO from the mergeSplit transaction to the same owner address
   const transferHex3 = await stasTransfer.signed(tokenOwnerPrivateKey, tokenUtxosFromMergeSplitTx[1], tokenOwnerAddress, utxoTemplateForFees, paymentPrivateKey);
-  console.log('Transfer3 Transaction Hex: ', transferHex3);
+  console.log('Transfer3 Transaction Hex: ', transferHex3.toString());
   const tokenUtxoFromTransfer3 = utility.getUtxoFromTx(transferHex3, 0);
 
 
@@ -104,25 +104,25 @@ const fullCycleTestNonBroadcast = async () => {
   // This example will take the STAS UTXO from the transferHex2 transaction and create an offer to swap it for the transactionHex3 transaction STAS UTXO
   const wantedDataForCreateSwap = {satoshis: tokenUtxoFromTransfer3.satoshis, script: tokenUtxoFromTransfer3.script};
   const offerHex = await stasCreateSwap.signed(tokenOwnerPrivateKey, tokenUtxoFromTransfer2, wantedDataForCreateSwap);
-  console.log('Offer Transaction Hex: ', offerHex);
+  console.log('Offer Transaction Hex: ', offerHex.toString());
 
 
   // We will now complete the swap by adding in all remaining parameters required to call the stasAcceptSwap function
   const swapHex = await stasAcceptSwap.signed(offerHex, tokenOwnerPrivateKey, transferHex2, transferHex3, tokenUtxoFromTransfer3.vout, paymentPrivateKey, utxoTemplateForFees);
-  console.log('Swap Transaction Hex: ', swapHex);
+  console.log('Swap Transaction Hex: ', swapHex.toString());
 
 
   // Here we will now merge the two STAS UTXOs from the atomic swap into a single 10 satoshi STAS UTXO
   const stasData5 = {txHex: swapHex, vout: 0};
   const stasData6 = {txHex: swapHex, vout: 1};
   const mergeHex2 = await stasMerge.signed(tokenOwnerPrivateKey, stasData5, tokenOwnerPrivateKey, stasData6, tokenOwnerAddress, paymentPrivateKey, utxoTemplateForFees);
-  console.log('Merge2 Transaction Hex: ', mergeHex2);
+  console.log('Merge2 Transaction Hex: ', mergeHex2.toString());
   const tokenUtxoFromMergeTx2 = utility.getUtxoFromTx(mergeHex2, 0);
 
 
   // Here we are now transferring the token to the issuer address. This is required for the STAS-20 token as only the issuer is allowed to redeem the token.
   const transferHex4 = await stasTransfer.signed(tokenOwnerPrivateKey, tokenUtxoFromMergeTx2, issuerAddress, utxoTemplateForFees, paymentPrivateKey);
-  console.log('Transfer4 Transaction Hex: ', transferHex4);
+  console.log('Transfer4 Transaction Hex: ', transferHex4.toString());
   const tokenUtxoFromTransfer4 = utility.getUtxoFromTx(transferHex4, 0);
 
 
@@ -130,13 +130,13 @@ const fullCycleTestNonBroadcast = async () => {
   // Note that the first output will always be the p2pkh redemption output which will be the conversion back to native satoshis
   const splitDestinationsForRedeemSplit = [{address: issuerAddress, satoshis: 5}];
   const redeemSplitHex = await stasRedeemSplit.signed(issuerPrivateKey, tokenUtxoFromTransfer4, splitDestinationsForRedeemSplit, utxoTemplateForFees, paymentPrivateKey);
-  console.log('RedeemSplit Transaction Hex: ', redeemSplitHex);
+  console.log('RedeemSplit Transaction Hex: ', redeemSplitHex.toString());
   const tokenUtxosFromRedeemSplitTx = utility.getUtxoFromTx(redeemSplitHex, 1);
 
 
   // Now we will redeem the final STAS UTXO back to native satoshis which completes the full cycle.
   const redeemHex = await stasRedeem.signed(issuerPrivateKey, tokenUtxosFromRedeemSplitTx, utxoTemplateForFees, paymentPrivateKey);
-  console.log('Redeem Transaction Hex: ', redeemHex);
+  console.log('Redeem Transaction Hex: ', redeemHex.toString());
 
   console.log('Full Cycle Non Broadcast Test Completed');
 };

--- a/tests/nonBroadcastMint.js
+++ b/tests/nonBroadcastMint.js
@@ -28,10 +28,10 @@ const issueData = [{
 
 const mintNonBroadcast = async () => {
   const contractHex = await stasContract.signed(issuerPrivateKey, utxoTemplateForContract, utxoTemplateForFees, paymentPrivateKey, tokenSchemaTemplate, 10);
-  console.log('Contract Transaction Hex: ', contractHex);
+  console.log('Contract Transaction Hex: ', contractHex.toString());
   const contractUtxo = utility.getUtxoFromTx(contractHex, 0);
   const issueHex = await stasIssuance.signed(issuerPrivateKey, issueData, contractUtxo, utxoTemplateForFees, paymentPrivateKey, true, tokenSchemaTemplate.symbol, 'STAS-20');
-  console.log('Issue Transaction Hex: ', issueHex);
+  console.log('Issue Transaction Hex: ', issueHex.toString());
 };
 
 mintNonBroadcast();

--- a/unitTests/dummyData.js
+++ b/unitTests/dummyData.js
@@ -10,7 +10,7 @@ class DummyData {
   
       this.privateKeyString = 'KxuLBg6YMTizTypfxz2E8MdSEo1UQzu2cnqT9iUYVYTchXHZMehK';
       this.privateKey = bsv.PrivateKey.fromString(this.privateKeyString);
-      this.publicKey = bsv.PublicKey.fromPrivateKey(this.privateKey);
+      this.publicKey = this.privateKey.publicKey.toString('hex')
       this.publicKeyString = this.publicKey.toString('hex');
       this.address = bsv.Address.fromPrivateKey(this.privateKey);
       this.addressString = this.address.toString();


### PR DESCRIPTION
Return un-serialized transactions
As ARC broadcast endpoints are poised to become the new standard, we're updating our library to make the conversion to the extended format seamless, negating the necessity of handling additional input data for this process.

For optimal usage of ARC, the transaction must be converted to the extended format, which requires the scriptPubKey and satoshi value for each input. By ensuring the non-serialized transaction is returned, these components will already be included within the transaction returned by the functions. This eliminates the need for any subsequent intervention to reintroduce this data before transitioning to the extended format.

For more information on the ARC transaction processor please see this documentation
https://bitcoin-sv.github.io/arc/#/

To continue using the library as per normal it will require that transactions are serialized once returned from the functions by simply converting them to string format ("toString()")

In addition a bug fix has been added for a utility function regarding BN.js library